### PR TITLE
ci: bake poetry into CI image + re-enable pip/poetry/npm volume caches

### DIFF
--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -13,7 +13,7 @@
 # scan-deps-frontend ─┬──> frontend ──────────────────────────────────┤                   ├──> deploy
 #                     └──> build-frontend ────────────────────────────┴──> scan-frontend ─┘
 #
-# Expected time: ~25-28 min
+# Expected time: ~20-23 min
 # Note: pipeline timeout is set to 120min via Woodpecker SQLite repos.timeout —
 # the top-level 'timeout' key is not supported in Woodpecker v3.x schema.
 #
@@ -71,18 +71,20 @@ steps:
     image: *ci_python_image
     depends_on:
       - scan-deps-backend
-    # volumes disabled: Woodpecker agent next-bef0abaa4a has a DNS name bug for
-    # hostPath volumes (/ prefix → leading hyphen = invalid). Re-enable once patched.
+    # Volume cache for pip and poetry virtualenvs
+    # Re-enabled 2026-03-23: Woodpecker v3.12.0 fixed DNS name bug for hostPath volumes
+    volumes:
+      - /cache/batchivo/pip:/root/.cache/pip
+      - /cache/batchivo/poetry:/root/.cache/pypoetry
     environment:
       DATABASE_URL: postgresql+psycopg://test:test@postgres:5432/test_batchivo
       SECRET_KEY: test-secret-key-for-ci-testing-minimum-32-chars
       PGPASSWORD: test
     commands:
       - cd backend
-      - pip install --quiet poetry
       - echo "=== Installing dependencies ==="
+      # poetry is pre-installed in ci-python:3.12 image; pip cache mounted at /root/.cache/pip
       - poetry install --no-interaction --quiet --extras dev
-      - apt-get update -qq && apt-get install -y -qq postgresql-client > /dev/null
       - echo "=== Waiting for postgres to be ready ==="
       - until pg_isready -h postgres -U test -q 2>/dev/null; do echo "postgres not ready, retrying..."; sleep 1; done
       - echo "Postgres is ready"
@@ -101,7 +103,9 @@ steps:
     image: *node_image
     depends_on:
       - scan-deps-frontend
-    # volumes disabled: same Woodpecker agent DNS name bug as backend step above
+    # Volume cache for npm - re-enabled 2026-03-23 (Woodpecker v3.12.0 fixes DNS name bug)
+    volumes:
+      - /cache/batchivo/npm:/root/.npm
     commands:
       - cd frontend
       - echo "=== Installing dependencies ==="
@@ -287,5 +291,7 @@ steps:
         done
         echo "Failed after 3 attempts"
         exit 1
-# Note: volumes disabled 2026-03-17 — Woodpecker agent next-bef0abaa4a DNS name bug
+# Note: volumes re-enabled 2026-03-23 — Woodpecker v3.12.0 fixed the DNS name bug
+# (was disabled 2026-03-17 due to Woodpecker agent next-bef0abaa4a DNS label bug)
+# Note: poetry now pre-installed in ci-python:3.12 image (Dockerfile.ci updated 2026-03-23)
 # Note: 2026-03-22 — if all pipelines fail fast with "cannot ack workflow" errors, restart woodpecker-server pod (SQLite queue state corruption after 5+ days uptime)

--- a/backend/Dockerfile.ci
+++ b/backend/Dockerfile.ci
@@ -1,8 +1,11 @@
 # CI test image for batchivo backend
-# Extends python:3.12-slim with postgresql-client pre-installed
-# so the test pipeline does not re-install apt packages on every run.
+# Extends python:3.12-slim with postgresql-client and poetry pre-installed
+# so the test pipeline does not re-install apt packages or poetry on every run.
 FROM python:3.12-slim
 
 RUN apt-get update -qq \
     && apt-get install -y -qq postgresql-client \
     && rm -rf /var/lib/apt/lists/*
+
+# Pre-install Poetry so every CI run skips this install step (~30s saved per build)
+RUN pip install --no-cache-dir "poetry>=2.0.0"


### PR DESCRIPTION
## Summary

Implements two CI speed improvements identified by Atlas (SRE) after observing a live pipeline run on 2026-03-23:

- **Bake poetry into `ci-python:3.12` image** — eliminates `pip install --quiet poetry` on every backend test step (~30s saved per run). The CI image (`Dockerfile.ci`) previously only pre-installed `postgresql-client`.
- **Re-enable volume caches for pip, poetry virtualenvs, and npm** — Woodpecker v3.12.0 fixed the DNS name bug (`next-bef0abaa4a`) that caused hostPath volume failures. Caches were disabled on 2026-03-17. Now that v3.12.0 is deployed, re-enabling saves `poetry install` time on cache-warm runs.

Also removes the now-redundant `apt-get install postgresql-client` line from the `backend` pipeline step (already in the CI image).

**Expected improvement:** ~25-28 min → ~20-23 min (first run after image rebuild), improving further on cache-warm runs as poetry virtualenv is preserved.

**Dependency:** This PR triggers a `ci-python:3.12` image rebuild via `ci-image.yml` (path filter: `backend/Dockerfile.ci`). The `build.yml` changes take effect on the subsequent pipeline run after the new CI image is pushed.

## Test plan

- [ ] Verify `ci-image.yml` pipeline triggers and pushes a new `ci-python:3.12` image
- [ ] Confirm next `build.yml` pipeline run skips `pip install poetry` step
- [ ] Confirm volume mounts are accepted by Woodpecker Kubernetes backend (no DNS label errors)
- [ ] Compare backend step timing before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)