### PR TITLE
Upgrade Batchivo Cloudflare tunnel connector

### DIFF
--- a/infrastructure/k8s/cloudflare-tunnel/deployment.yaml
+++ b/infrastructure/k8s/cloudflare-tunnel/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         runAsGroup: 65532
       containers:
       - name: cloudflared
-        image: cloudflare/cloudflared:2026.3.0
+        image: cloudflare/cloudflared:2026.7.3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## What changed

- Upgrade the Batchivo Cloudflare Tunnel connector from `2026.3.0` to `2026.7.3`.

## Why

Production investigation found both tunnel replicas reporting that `2026.3.0` is outdated, alongside Cloudflare edge disconnects and abruptly cancelled proxied requests. Those failures coincide with storefront product-fetch errors reported to Sentry.

## Impact

Argo CD will roll the two tunnel replicas without changing the public hostname, tunnel token, origin service, or HTTP protocol.

## Validation

- Kubernetes server-side dry run succeeds.
- Current Batchivo API health and product endpoints return HTTP 200.
- CORS preflight for the production storefront returns the expected origin, headers, and methods.